### PR TITLE
Fix all linting errors

### DIFF
--- a/src/ymago/core/batch_parser.py
+++ b/src/ymago/core/batch_parser.py
@@ -310,5 +310,8 @@ async def _write_rejected_rows(
             raw_data_str = json.dumps(row.raw_data).replace('"', '""')
             error_msg_escaped = row.error_message.replace('"', '""')
 
-            line = f'{row.row_number},"{row.error_type}","{error_msg_escaped}","{raw_data_str}"\n'
+            line = (
+                f'{row.row_number},"{row.error_type}",'
+                f'"{error_msg_escaped}","{raw_data_str}"\n'
+            )
             await f.write(line)

--- a/src/ymago/models.py
+++ b/src/ymago/models.py
@@ -263,7 +263,10 @@ class GenerationRequest(BaseModel):
 
     from_image: Optional[str] = Field(
         default=None,
-        description="URL or path of source image for image-to-image/image-to-video generation",
+        description=(
+            "URL or path of source image for "
+            "image-to-image/image-to-video generation"
+        ),
     )
 
     quality: Optional[str] = Field(

--- a/tests/integration/test_batch_resilience.py
+++ b/tests/integration/test_batch_resilience.py
@@ -82,7 +82,8 @@ class TestBatchResilience:
                     resume=True,
                 )
 
-                # Should process only req4 and req5 (req1 and req3 were successful, req2 failed)
+                # Should process only req4 and req5
+                # (req1 and req3 were successful, req2 failed)
                 assert summary.total_requests == 5
                 assert summary.successful == 2  # req4 and req5 newly processed
                 assert summary.failed == 0  # No new failures
@@ -107,14 +108,16 @@ class TestBatchResilience:
             # Create checkpoint file with mixed valid and invalid JSON
             with open(state_file, "w") as f:
                 f.write(
-                    '{"request_id": "req1", "status": "success", "output_path": "/path1"}\n'
+                    '{"request_id": "req1", "status": "success", '
+                    '"output_path": "/path1"}\n'
                 )
                 f.write("invalid json line that should be skipped\n")
                 f.write(
                     '{"request_id": "req2", "status": "success"}\n'
                 )  # Missing output_path
                 f.write(
-                    '{"request_id": "req3", "status": "success", "output_path": "/path3"}\n'
+                    '{"request_id": "req3", "status": "success", '
+                    '"output_path": "/path3"}\n'
                 )
 
             async def request_generator():
@@ -261,7 +264,7 @@ class TestBatchResilience:
         request_times = []
 
         # Make 5 requests rapidly
-        for i in range(5):
+        for _ in range(5):
             await limiter.acquire()
             request_times.append(time.time() - start_time)
 

--- a/tests/unit/test_batch_parser.py
+++ b/tests/unit/test_batch_parser.py
@@ -5,6 +5,7 @@ This module tests the streaming parser for CSV and JSONL files with
 comprehensive coverage of error handling and validation scenarios.
 """
 
+import json
 import tempfile
 from pathlib import Path
 
@@ -250,9 +251,15 @@ class TestParseBatchInput:
 
     async def test_parse_jsonl_file_valid(self):
         """Test parsing valid JSONL file."""
-        jsonl_content = """{"prompt": "A beautiful sunset", "output_filename": "sunset", "seed": 42}
-{"prompt": "A mountain landscape", "output_filename": "mountain", "seed": 123}
-"""
+        jsonl_lines = [
+            {"prompt": "A beautiful sunset", "output_filename": "sunset", "seed": 42},
+            {
+                "prompt": "A mountain landscape",
+                "output_filename": "mountain",
+                "seed": 123,
+            },
+        ]
+        jsonl_content = "\n".join(json.dumps(line) for line in jsonl_lines)
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
             f.write(jsonl_content)


### PR DESCRIPTION
This commit fixes all linting errors reported by `ruff`.

The changes include:
- Fixing long lines in various files.
- Using `typing.Annotated` for `typer` arguments to fix `B008`.
- Fixing boolean comparisons to fix `E712`.
- Replacing unused loop variables with `_` to fix `B007`.
- Reformatting multiline strings in tests.