### PR TITLE
Fix RuntimeWarning for unawaited coroutines

### DIFF
--- a/src/ymago/core/generation.py
+++ b/src/ymago/core/generation.py
@@ -5,6 +5,7 @@ This module coordinates the entire image generation process, from API calls
 to file storage, with comprehensive error handling and cleanup.
 """
 
+import asyncio
 import logging
 import tempfile
 import time
@@ -229,8 +230,10 @@ async def process_generation_job(
             )
 
             # Send webhook notification (fire-and-forget)
-            notification_service.send_notification_async(
-                session, webhook_url, success_payload
+            asyncio.create_task(
+                notification_service.send_notification_async(
+                    session, webhook_url, success_payload
+                )
             )
 
         # Step 10: Create and populate result
@@ -287,8 +290,10 @@ async def process_generation_job(
                 )
 
                 # Send failure webhook notification (fire-and-forget)
-                notification_service.send_notification_async(
-                    session, webhook_url, failure_payload
+                asyncio.create_task(
+                    notification_service.send_notification_async(
+                        session, webhook_url, failure_payload
+                    )
                 )
             except Exception as webhook_error:
                 # Log webhook error but don't fail the main exception


### PR DESCRIPTION
The `notification_service.send_notification_async` coroutine was being called without being awaited, leading to a `RuntimeWarning`.

This commit fixes the warning by wrapping the calls in `asyncio.create_task`. This schedules the coroutine to run on the event loop as a background task, which is the correct way to handle "fire-and-forget" asynchronous operations in asyncio.

The changes are:
- Added `import asyncio` to `src/ymago/core/generation.py`.
- Wrapped the two calls to `send_notification_async` in `asyncio.create_task` to ensure they are properly scheduled on the event loop.