### PR TITLE
Fix mypy linting issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
     "types-aiofiles>=24.1.0.20250822",
     "bandit>=1.8.6",
     "tomli>=2.2.1",
+    "pydantic>=2.0,<3.0",
 ]
 docs = [
     "sphinx>=8.0.0",
@@ -122,6 +123,7 @@ select = ["E", "F", "B", "I"] # flake8, pyflakes, bugbear, isort
 [tool.mypy]
 python_version = "3.10"
 strict = true
+plugins = ["pydantic.mypy"]
 
 [[tool.mypy.overrides]]
 module = [
@@ -134,6 +136,8 @@ module = [
     "aiohttp.*",
     "typer.*",
     "rich.*",
+    "gcloud.aio.storage",
+    "aioboto3",
 ]
 ignore_missing_imports = true
 

--- a/src/ymago/config.py
+++ b/src/ymago/config.py
@@ -247,7 +247,7 @@ async def load_config() -> Settings:
         env_overrides["cloud_storage"] = cloud_storage_overrides
 
     # Webhook configuration from environment
-    webhook_overrides = {}
+    webhook_overrides: dict[str, Any] = {}
 
     webhook_enabled = os.getenv("YMAGO_WEBHOOK_ENABLED")
     if webhook_enabled:

--- a/src/ymago/core/cloud_storage.py
+++ b/src/ymago/core/cloud_storage.py
@@ -9,7 +9,7 @@ and Cloudflare R2.
 import logging
 import mimetypes
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
 import aiofiles
@@ -60,6 +60,7 @@ class S3StorageBackend(StorageUploader):
             aws_secret_access_key: AWS secret key (optional, uses IAM if not provided)
             aws_region: AWS region
         """
+        super().__init__(destination_url=destination_url)
         if aioboto3 is None:
             raise ImportError(
                 "AWS S3 support requires 'aioboto3'. "
@@ -81,9 +82,9 @@ class S3StorageBackend(StorageUploader):
         if not self.bucket_name:
             raise ValueError("S3 URL must include bucket name: s3://bucket-name/path/")
 
-    def _get_session_kwargs(self) -> dict:
+    def _get_session_kwargs(self) -> Dict[str, Any]:
         """Get session configuration for aioboto3."""
-        kwargs = {"region_name": self.aws_region}
+        kwargs: Dict[str, Any] = {"region_name": self.aws_region}
 
         if self.aws_access_key_id and self.aws_secret_access_key:
             kwargs.update(
@@ -265,7 +266,7 @@ class R2StorageBackend(S3StorageBackend):
         self.r2_account_id = r2_account_id
         self.endpoint_url = f"https://{r2_account_id}.r2.cloudflarestorage.com"
 
-    def _get_session_kwargs(self) -> dict:
+    def _get_session_kwargs(self) -> Dict[str, Any]:
         """Get session configuration for R2."""
         kwargs = super()._get_session_kwargs()
         kwargs["endpoint_url"] = self.endpoint_url
@@ -281,7 +282,10 @@ class GCSStorageBackend(StorageUploader):
     """
 
     def __init__(
-        self, destination_url: str, service_account_path: Optional[Path] = None
+        self,
+        destination_url: str,
+        service_account_path: Optional[Path] = None,
+        **kwargs: Any,
     ):
         """
         Initialize GCS storage backend.
@@ -290,6 +294,7 @@ class GCSStorageBackend(StorageUploader):
             destination_url: GCS URL (e.g., 'gs://bucket-name/path/')
             service_account_path: Path to service account JSON file (optional)
         """
+        super().__init__(destination_url=destination_url, **kwargs)
         if Storage is None:
             raise ImportError(
                 "Google Cloud Storage support requires 'gcloud-aio-storage'. "
@@ -344,7 +349,7 @@ class GCSStorageBackend(StorageUploader):
 
         try:
             # Initialize storage client
-            storage_kwargs = {}
+            storage_kwargs: Dict[str, Any] = {}
             if self.service_account_path:
                 storage_kwargs["service_file"] = str(self.service_account_path)
 
@@ -392,7 +397,7 @@ class GCSStorageBackend(StorageUploader):
 
         try:
             # Initialize storage client
-            storage_kwargs = {}
+            storage_kwargs: Dict[str, Any] = {}
             if self.service_account_path:
                 storage_kwargs["service_file"] = str(self.service_account_path)
 
@@ -419,7 +424,7 @@ class GCSStorageBackend(StorageUploader):
             return False
 
         try:
-            storage_kwargs = {}
+            storage_kwargs: Dict[str, Any] = {}
             if self.service_account_path:
                 storage_kwargs["service_file"] = str(self.service_account_path)
 
@@ -440,7 +445,7 @@ class GCSStorageBackend(StorageUploader):
             return False
 
         try:
-            storage_kwargs = {}
+            storage_kwargs: Dict[str, Any] = {}
             if self.service_account_path:
                 storage_kwargs["service_file"] = str(self.service_account_path)
 

--- a/src/ymago/core/generation.py
+++ b/src/ymago/core/generation.py
@@ -139,9 +139,10 @@ async def process_generation_job(
                 )
                 storage_kwargs["aws_region"] = cs_config.aws_region
             elif destination_url.startswith("gs://"):
-                storage_kwargs["service_account_path"] = (
-                    cs_config.gcp_service_account_path
-                )
+                if cs_config.gcp_service_account_path:
+                    storage_kwargs["service_account_path"] = str(
+                        cs_config.gcp_service_account_path
+                    )
             elif destination_url.startswith("r2://"):
                 if not all(
                     [
@@ -231,7 +232,7 @@ async def process_generation_job(
 
             # Send webhook notification (fire-and-forget)
             asyncio.create_task(
-                notification_service.send_notification_async(
+                notification_service.send_notification(
                     session, webhook_url, success_payload
                 )
             )
@@ -291,7 +292,7 @@ async def process_generation_job(
 
                 # Send failure webhook notification (fire-and-forget)
                 asyncio.create_task(
-                    notification_service.send_notification_async(
+                    notification_service.send_notification(
                         session, webhook_url, failure_payload
                     )
                 )

--- a/src/ymago/core/notifications.py
+++ b/src/ymago/core/notifications.py
@@ -156,10 +156,10 @@ class NotificationService:
         """
         try:
             # Update retry configuration based on instance settings
-            self._send_webhook_request.retry.stop = stop_after_attempt(
+            self._send_webhook_request.retry.stop = stop_after_attempt(  # type: ignore[attr-defined]
                 self.retry_attempts
             )
-            self._send_webhook_request.retry.wait = wait_random_exponential(
+            self._send_webhook_request.retry.wait = wait_random_exponential(  # type: ignore[attr-defined]
                 multiplier=self.retry_backoff_factor, max=30
             )
 
@@ -170,26 +170,6 @@ class NotificationService:
             # Log error but don't raise - this is fire-and-forget
             logger.error(f"Failed to send webhook notification to {webhook_url}: {e}")
 
-    def send_notification_async(
-        self, session: aiohttp.ClientSession, webhook_url: str, payload: WebhookPayload
-    ) -> asyncio.Task:
-        """
-        Create an async task for sending webhook notification.
-
-        This is a convenience method that creates the asyncio.Task for
-        fire-and-forget webhook delivery.
-
-        Args:
-            session: aiohttp client session
-            webhook_url: Target webhook URL
-            payload: Webhook payload to send
-
-        Returns:
-            asyncio.Task: Task that can be awaited or ignored
-        """
-        return asyncio.create_task(
-            self.send_notification(session, webhook_url, payload)
-        )
 
 
 def create_success_payload(

--- a/src/ymago/core/storage.py
+++ b/src/ymago/core/storage.py
@@ -8,7 +8,7 @@ this to support cloud storage providers like AWS S3, Google Cloud Storage, etc.
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Dict, Optional, Type
+from typing import Any, Dict, Optional, Type
 from urllib.parse import urlparse
 
 import aiofiles
@@ -44,7 +44,9 @@ class StorageBackendRegistry:
         cls._backends[scheme] = backend_class
 
     @classmethod
-    def create_backend(cls, destination_url: str, **kwargs) -> "StorageUploader":
+    def create_backend(
+        cls, destination_url: str, **kwargs: Any
+    ) -> "StorageUploader":
         """
         Create appropriate backend based on destination URL scheme.
 
@@ -88,6 +90,9 @@ class StorageUploader(ABC):
     backends. Implementations should handle the specifics of each storage type
     while providing a consistent async interface.
     """
+
+    def __init__(self, destination_url: str, **kwargs: Any):
+        self.destination_url = destination_url
 
     @abstractmethod
     async def upload(self, file_path: Path, destination_key: str) -> str:

--- a/tests/core/test_generation.py
+++ b/tests/core/test_generation.py
@@ -503,7 +503,7 @@ class TestGenerationWithCloudStorage:
             # Verify cloud storage backend was created and used
             mock_registry.create_backend.assert_called_once_with(
                 "gs://test-bucket/uploads/",
-                service_account_path=Path("/path/to/service-account.json"),
+                service_account_path="/path/to/service-account.json",
             )
             mock_backend.upload.assert_called_once()
 
@@ -598,10 +598,10 @@ class TestGenerationWithWebhooks:
             mock_notification_class.assert_called_once_with(
                 timeout_seconds=30, retry_attempts=3, retry_backoff_factor=2.0
             )
-            mock_notification_service.send_notification_async.assert_called_once()
+            mock_notification_service.send_notification.assert_called_once()
 
             # Verify webhook call arguments
-            call_args = mock_notification_service.send_notification_async.call_args
+            call_args = mock_notification_service.send_notification.call_args
             assert call_args[0][0] == mock_session  # session
             assert (
                 call_args[0][1] == "https://webhook.example.com/notify"
@@ -656,10 +656,10 @@ class TestGenerationWithWebhooks:
                 )
 
             # Verify failure notification was sent
-            mock_notification_service.send_notification_async.assert_called_once()
+            mock_notification_service.send_notification.assert_called_once()
 
             # Verify failure webhook call arguments
-            call_args = mock_notification_service.send_notification_async.call_args
+            call_args = mock_notification_service.send_notification.call_args
             payload = call_args[0][2]
             assert payload.job_status == "failure"
             assert payload.error_message == "API error"

--- a/tests/core/test_notifications.py
+++ b/tests/core/test_notifications.py
@@ -253,8 +253,10 @@ class TestNotificationService:
 
             async with aiohttp.ClientSession() as session:
                 # Create async task
-                task = service.send_notification_async(
-                    session, "https://webhook.example.com/notify", payload
+                task = asyncio.create_task(
+                    service.send_notification(
+                        session, "https://webhook.example.com/notify", payload
+                    )
                 )
 
                 assert isinstance(task, asyncio.Task)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -2362,6 +2362,7 @@ dev = [
     { name = "aresponses" },
     { name = "bandit" },
     { name = "mypy" },
+    { name = "pydantic" },
     { name = "ruff" },
     { name = "tomli" },
     { name = "types-aiofiles" },
@@ -2419,6 +2420,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.17.1" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=3.0.0" },
     { name = "pydantic", specifier = ">=2.0,<3.0" },
+    { name = "pydantic", marker = "extra == 'dev'", specifier = ">=2.0,<3.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.1.0" },
     { name = "pytest-benchmark", marker = "extra == 'test'", specifier = ">=5.0.0" },


### PR DESCRIPTION
This commit fixes a series of mypy linting errors across the codebase.

The changes include:
- Adding and correcting type hints in various modules.
- Enabling the pydantic mypy plugin to correctly handle pydantic models.
- Ignoring missing type stubs for third-party libraries (`aioboto3`, `gcloud-aio-storage`).
- Refactoring the notification service to remove a redundant async wrapper method.
- Updating tests to reflect the changes in the codebase.