### PR TITLE
Fix mypy errors in cloud_storage.py

### DIFF
--- a/src/ymago/core/cloud_storage.py
+++ b/src/ymago/core/cloud_storage.py
@@ -9,7 +9,7 @@ and Cloudflare R2.
 import logging
 import mimetypes
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Type
 from urllib.parse import urlparse
 
 import aiofiles
@@ -30,10 +30,13 @@ try:
 except ImportError:
     aioboto3 = None
 
+Storage: Optional[Type[Any]] = None
 try:
-    from gcloud.aio.storage import Storage
+    from gcloud.aio.storage import Storage as _Storage
+
+    Storage = _Storage
 except ImportError:
-    Storage = None
+    pass
 
 
 class S3StorageBackend(StorageUploader):
@@ -128,7 +131,7 @@ class S3StorageBackend(StorageUploader):
         session = aioboto3.Session(**self._get_session_kwargs())
 
         try:
-            async with session.client("s3") as s3_client:  # type: ignore
+            async with session.client("s3") as s3_client:
                 # Upload file with streaming
                 await s3_client.upload_file(
                     str(file_path),
@@ -173,7 +176,7 @@ class S3StorageBackend(StorageUploader):
         session = aioboto3.Session(**self._get_session_kwargs())
 
         try:
-            async with session.client("s3") as s3_client:  # type: ignore
+            async with session.client("s3") as s3_client:
                 # Upload bytes
                 await s3_client.put_object(
                     Bucket=self.bucket_name,
@@ -198,7 +201,7 @@ class S3StorageBackend(StorageUploader):
         session = aioboto3.Session(**self._get_session_kwargs())
 
         try:
-            async with session.client("s3") as s3_client:  # type: ignore
+            async with session.client("s3") as s3_client:
                 await s3_client.head_object(Bucket=self.bucket_name, Key=s3_key)
                 return True
         except Exception:
@@ -214,7 +217,7 @@ class S3StorageBackend(StorageUploader):
         session = aioboto3.Session(**self._get_session_kwargs())
 
         try:
-            async with session.client("s3") as s3_client:  # type: ignore
+            async with session.client("s3") as s3_client:
                 await s3_client.delete_object(Bucket=self.bucket_name, Key=s3_key)
                 return True
         except Exception:


### PR DESCRIPTION
This commit resolves a series of mypy errors in the `src/ymago/core/cloud_storage.py` file.

The primary changes are:
-   Resolved a type conflict with the optional `gcloud.aio.storage.Storage` import. The `Storage` variable is now explicitly typed as `Optional[Type[Any]]` before the import attempt, which satisfies the type checker when the import fails.
-   Removed several unused `type: ignore` comments that were no longer necessary.

All changes have been verified with mypy and the existing test suite to ensure correctness and prevent regressions.